### PR TITLE
Add indexing of fixed-length data elements

### DIFF
--- a/tests/api/matcher/fixed_length.rs
+++ b/tests/api/matcher/fixed_length.rs
@@ -1,0 +1,106 @@
+use crate::prelude::*;
+
+#[test]
+fn fixed_length_fields() -> TestResult {
+    let record = ByteRecord::from_bytes(&ADA_LOVELACE)?;
+    let options = MatchOptions::default();
+
+    let matcher = RecordMatcher::new("005[:4] == '2025'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    let matcher = RecordMatcher::new("005[4:] == '0720173911.0'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 00-05 - Date entered on file
+    let matcher = RecordMatcher::new("008[0:6] == '950316'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    let matcher = RecordMatcher::new("008[:6] == '950316'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 06 - Direct or indirect geographic subdivision
+    let matcher = RecordMatcher::new("008[6] == 'n'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 07 - Romanization scheme
+    let matcher = RecordMatcher::new("008[7] == '|'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 08 - Language of catalog
+    let matcher = RecordMatcher::new("008[8] == '|'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 09 - Kind of record
+    let matcher = RecordMatcher::new("008[9] == 'a'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 10 - Descriptive cataloging rules
+    let matcher = RecordMatcher::new("008[10] == 'z'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 11 - Subject heading system/thesaurus
+    let matcher = RecordMatcher::new("008[11] == 'z'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 12 - Type of series
+    let matcher = RecordMatcher::new("008[12] == 'n'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 13 - Numbered or unnumbered series
+    let matcher = RecordMatcher::new("008[13] == 'n'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 14 - Heading use-main or added entry
+    let matcher = RecordMatcher::new("008[14] == 'a'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 15 - Heading use-subject added entry
+    let matcher = RecordMatcher::new("008[15] == 'a'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 16 - Heading use-series added entry
+    let matcher = RecordMatcher::new("008[16] == 'b'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 17 - Type of subject subdivision
+    let matcher = RecordMatcher::new("008[17] == 'n'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 28 - Type of government agency
+    let matcher = RecordMatcher::new("008[28] == ' '")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 29 - Reference evaluation
+    let matcher = RecordMatcher::new("008[29] == '|'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 31 - Record update in process
+    let matcher = RecordMatcher::new("008[31] == 'a'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 32 - Undifferentiated personal name
+    let matcher = RecordMatcher::new("008[32] == 'a'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 33 - Level of establishment
+    let matcher = RecordMatcher::new("008[33] == 'a'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 38 - Modified record
+    let matcher = RecordMatcher::new("008[38] == '|'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // 39 - Cataloging source
+    let matcher = RecordMatcher::new("008[39] == 'c'")?;
+    assert!(matcher.is_match(&record, &options));
+
+    // invalid index
+    let matcher = RecordMatcher::new("008[40] == 'X'")?;
+    assert!(!matcher.is_match(&record, &options));
+
+    // invalid range
+    let matcher = RecordMatcher::new("008[0:1024] == 'X'")?;
+    assert!(!matcher.is_match(&record, &options));
+
+    Ok(())
+}

--- a/tests/api/matcher/mod.rs
+++ b/tests/api/matcher/mod.rs
@@ -2,6 +2,7 @@ mod comparison;
 mod connectives;
 mod contains;
 mod ends_with;
+mod fixed_length;
 mod regex;
 mod starts_with;
 mod strsim;


### PR DESCRIPTION
## Summary

MARC21 contains fixed-length data elements, such as field 008. To work effectively with these fields, it would be useful to be able to access substrings by specifying a position or a range. This functionality will initially only be possible for control fields.

## Examples

```shell
$ marc21 print ada.mrc | grep '008'
008 950316n||azznnaabn           | aaa    |c

$ marc21 filter '008[0:5] == "950316"' ada.mrc -o out.mrc
$ marc21 filter '008[:5] == "950316"' ada.mrc -o out.mrc
$ marc21 filter '008[6] == "n"' ada.mrc -o out.mrc
```

Closes #63 