### PR TITLE
build: Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -631,9 +631,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "marc21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ winnow = { version = "1.0" }
 
 [dev-dependencies]
 serde_test = { version = "1.0" }
-trycmd = { version = "1.1" }
+trycmd = { version = "1.2" }
 
 [[test]]
 path = "tests/fuzz/lib.rs"

--- a/crates/marc21-cli/Cargo.toml
+++ b/crates/marc21-cli/Cargo.toml
@@ -20,9 +20,9 @@ name = "e2e"
 
 [dependencies]
 bstr = { version = "1.12", features = ["std"], default-features = false }
-clap_complete = { version = "4.5", optional = true }
+clap_complete = { version = "4.6", optional = true }
 clap_mangen = { version = "0.3", optional = true }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 csv = { version = "1.4" }
 flate2 = { version = "1.1" }
 indicatif = { version = "0.18" }
@@ -32,7 +32,7 @@ sha2 = { version = "0.11" }
 
 [dev-dependencies]
 anyhow = { version = "1.0" }
-assert_cmd = { version = "2.1" }
+assert_cmd = { version = "2.2" }
 assert_fs = { version = "1.1" }
 predicates = { version = "3.1" }
 


### PR DESCRIPTION
# Summary

- Update `trycmd` to `1.2`
- Update `clap_complete` to `4.6`
- Update `clap` to `4.6`
- Update `assert_cmd` to `2.2`