### PR TITLE
query: fix data field projection when field is missing

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -332,7 +332,15 @@ fn project_data_field_path<'a>(
     }
 
     if result.is_empty() {
-        result.push(vec![Value::from(&EMPTY_BYTE_STRING)]);
+        // If no field was found that could produce a row, an empty cell
+        // must be created for each column. Otherwise, the number of
+        // columns generated might vary.
+        result.push(
+            (0..path.codes.len())
+                .into_iter()
+                .map(|_| Value::from(&EMPTY_BYTE_STRING))
+                .collect(),
+        );
     }
 
     result

--- a/tests/api/query.rs
+++ b/tests/api/query.rs
@@ -150,3 +150,15 @@ fn query_data_field() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn query_missing_field() -> TestResult {
+    let record = ByteRecord::from_bytes(&ADA_LOVELACE)?;
+    let options = MatchOptions::default();
+
+    let query = Query::new("001,101/1#{ a, b }")?;
+    let values = record.query(&query, &options);
+    assert_eq!(values, vec![vec!["119232022", "", ""]]);
+
+    Ok(())
+}


### PR DESCRIPTION
This change fix a bug in the data field projection (query). If there is no data field that could produce a row, an empty cell must be created **for each** column. Otherwise, the number of columns generated might vary between different records.