### PR TITLE
query: use wildcard character `*` to match all codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,21 +651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "marc21"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbaac1ddb448f31eb8881ef25fbd184e0b3e9ff0dcfedcc407d4ae30b704edf"
-dependencies = [
- "aho-corasick",
- "bstr",
- "flate2",
- "regex",
- "smallvec",
- "strsim",
- "winnow",
-]
-
-[[package]]
 name = "marc21-cli"
 version = "0.4.0"
 dependencies = [
@@ -679,7 +664,7 @@ dependencies = [
  "csv",
  "flate2",
  "indicatif",
- "marc21 0.4.0",
+ "marc21",
  "predicates",
  "rand",
  "sha2",
@@ -750,7 +735,7 @@ name = "polars-marc21"
 version = "0.1.0"
 dependencies = [
  "bstr",
- "marc21 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marc21",
  "pyo3",
 ]
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,5 +15,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bstr = { version = "1.12" }
-marc21 = { version = "0.4" }
+# marc21 = { version = "0.4" }
+marc21 = { path = "../" }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -140,12 +140,11 @@ def test_query_data_field(data_dir: Path) -> None:
 
     expected = pl.DataFrame({"column_1": ["piz"]})
     actual = scan_marc21(
-        path, "075{ b | 2 == 'gndspec' && b =^ 'p' }",
+        path,
+        "075{ b | 2 == 'gndspec' && b =^ 'p' }",
     ).collect()
     assert isinstance(actual, pl.DataFrame)
     assert_frame_equal(actual, expected)
-
-    
 
 
 def test_query_cartesian_product1(data_dir: Path) -> None:

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -126,6 +126,12 @@ def test_query_data_field(data_dir: Path) -> None:
     assert isinstance(actual, pl.DataFrame)
     assert_frame_equal(actual, expected)
 
+    # wildcard
+    expected = pl.DataFrame({"column_1": list("gfszwkv")})
+    actual = scan_marc21(path, "079.*").collect()
+    assert isinstance(actual, pl.DataFrame)
+    assert_frame_equal(actual, expected)
+
     # predicate
     expected = pl.DataFrame({"column_1": ["p"]})
     actual = scan_marc21(path, "075{ b | 2 == 'gndgen' }").collect()
@@ -138,6 +144,8 @@ def test_query_data_field(data_dir: Path) -> None:
     ).collect()
     assert isinstance(actual, pl.DataFrame)
     assert_frame_equal(actual, expected)
+
+    
 
 
 def test_query_cartesian_product1(data_dir: Path) -> None:

--- a/src/matcher/shared/mod.rs
+++ b/src/matcher/shared/mod.rs
@@ -64,6 +64,12 @@ pub(crate) fn parse_codes(i: &mut &[u8]) -> ModalResult<Vec<u8>> {
                 codes
             },
         ),
+        b'*'.value(
+            (b'0'..=b'9')
+                .chain(b'a'..=b'z')
+                .chain(b'A'..=b'Z')
+                .collect::<Vec<u8>>(),
+        ),
     ))
     .parse_next(i)
 }
@@ -84,4 +90,35 @@ pub(crate) fn parse_range(
         ']',
     )
     .parse_next(i)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::TestResult;
+
+    #[test]
+    fn test_parse_codes() -> TestResult {
+        macro_rules! parse_success {
+            ($i:expr, $o:expr) => {
+                assert_eq!(
+                    parse_codes.parse($i.as_bytes()).unwrap(),
+                    $o
+                );
+            };
+        }
+
+        parse_success!("a", vec![b'a']);
+        parse_success!("[ab]", vec![b'a', b'b']);
+        parse_success!("[aba]", vec![b'a', b'b']);
+        parse_success!(
+            "*",
+            (b'0'..=b'9')
+                .chain(b'a'..=b'z')
+                .chain(b'A'..=b'Z')
+                .collect::<Vec<_>>()
+        );
+
+        Ok(())
+    }
 }

--- a/tests/api/path.rs
+++ b/tests/api/path.rs
@@ -106,6 +106,15 @@ fn path_data_field() -> TestResult {
     let values = record.path(&path, &options);
     assert_eq!(values, vec!["28p", "sswd", "9.5p", "sswd"]);
 
+    // wildcard
+    let path = Path::new("065.*")?;
+    let values = record.path(&path, &options);
+    assert_eq!(values, vec!["28p", "sswd", "9.5p", "sswd"]);
+
+    let path = Path::new("065{ * }")?;
+    let values = record.path(&path, &options);
+    assert_eq!(values, vec!["28p", "sswd", "9.5p", "sswd"]);
+
     // empty path
     let path = Path::new("100{ _ | 2 == 'gndspec'  }")?;
     let values = record.path(&path, &options);

--- a/tests/api/query.rs
+++ b/tests/api/query.rs
@@ -139,6 +139,14 @@ fn query_data_field() -> TestResult {
     let values = record.query(&query, &options);
     assert_eq!(values, vec![vec!["28p", "sswd"], vec!["9.5p", "sswd"]]);
 
+    // wildcard
+    let query = Query::new("065.*")?;
+    let values = record.query(&query, &options);
+    assert_eq!(
+        values,
+        vec![vec!["28p"], vec!["sswd"], vec!["9.5p"], vec!["sswd"]]
+    );
+
     // empty query
     let query = Query::new("100{ _ | 2 == 'gndspec'  }")?;
     let values = record.query(&query, &options);


### PR DESCRIPTION
Closes #233 