### PR TITLE
matcher: rename leader field `base_address` to `base_addr`

### DIFF
--- a/docs/book/src/concepts/record-matcher.md
+++ b/docs/book/src/concepts/record-matcher.md
@@ -12,7 +12,7 @@ through [Boolean connectives] or [grouping].
 The leader matcher allows you to check the elements of the [leader]. The
 following fields can be checked:
 
-- `base_address` --- Base address of data (position 12-16)
+- `base_addr` --- Base address of data (position 12-16)
 - `encoding` --- Character coding scheme (position 09)
 - `length` --- Record length (position 00-04)
 - `status ` --- Record status (position 05)
@@ -42,7 +42,7 @@ the `--where` option. If the command returns the value `1`, the leader
 of this record meets the criterion; otherwise, it does not.
 
 ```console
-$ marc21 count tests/data/ada.mrc --where 'ldr.base_address > 500'
+$ marc21 count tests/data/ada.mrc --where 'ldr.base_addr > 500'
 1
 
 $ marc21 count tests/data/ada.mrc --where 'ldr.encoding != "a"'

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -74,9 +74,9 @@ def test_query_control_field(data_dir: Path) -> None:
 def test_query_leader(data_dir: Path) -> None:
     path = data_dir.joinpath("ada.mrc")
 
-    # base address
+    # base addr
     expected = pl.DataFrame({"column_1": ["589"]})
-    actual = scan_marc21(path, "ldr.base_address").collect()
+    actual = scan_marc21(path, "ldr.base_addr").collect()
     assert isinstance(actual, pl.DataFrame)
     assert_frame_equal(actual, expected)
 

--- a/src/leader.rs
+++ b/src/leader.rs
@@ -17,7 +17,7 @@ pub struct Leader {
     idef1: u8,
     idef2: u8,
     encoding: u8,
-    base_address: u32,
+    base_addr: u32,
     idef3: u8,
     idef4: u8,
     idef5: u8,
@@ -244,7 +244,7 @@ impl Leader {
     /// ```
     #[inline(always)]
     pub fn base_addr(&self) -> u32 {
-        self.base_address
+        self.base_addr
     }
 
     /// Write the leader into the given writer
@@ -275,7 +275,7 @@ impl Leader {
             self.idef1 as char,
             self.idef2 as char,
             self.encoding as char,
-            self.base_address,
+            self.base_addr,
             self.idef3 as char,
             self.idef4 as char,
             self.idef5 as char,
@@ -306,7 +306,7 @@ pub(crate) fn parse_leader(i: &mut &[u8]) -> ModalResult<Leader> {
         encoding: parse_space_or_ascii_graphic,
         _: '2', // indicator count
         _: '2', // subfield code length
-        base_address: parse_digits_u32,
+        base_addr: parse_digits_u32,
         idef3: parse_space_or_ascii_graphic,
         idef4: parse_space_or_ascii_graphic,
         idef5: parse_space_or_ascii_graphic,
@@ -332,7 +332,7 @@ mod tests {
                 idef1: b' ',
                 idef2: b' ',
                 encoding: b'a',
-                base_address: 589,
+                base_addr: 589,
                 idef3: b'n',
                 idef4: b'c',
                 idef5: b' ',
@@ -351,7 +351,7 @@ mod tests {
                 idef1: b' ',
                 idef2: b' ',
                 encoding: b'a',
-                base_address: 589,
+                base_addr: 589,
                 idef3: b'n',
                 idef4: b'c',
                 idef5: b' ',

--- a/src/matcher/leader/mod.rs
+++ b/src/matcher/leader/mod.rs
@@ -21,7 +21,7 @@ pub(crate) enum LeaderField {
 /// The LeaderMatcher can be used to check the leader fields. The
 /// following fields can be checked:
 ///
-/// - Base Address `ldr.base_address`,
+/// - Base Address `ldr.base_addr`,
 /// - Encoding `ldr.encoding`,
 /// - Length `ldr.length`,
 /// - Status`ldr.status`,
@@ -42,7 +42,7 @@ pub(crate) enum LeaderField {
 /// let leader = Leader::new(b"00000nz  a2200000oc 4500")?;
 /// let options = MatchOptions::default();
 ///
-/// let matcher = LeaderMatcher::new("ldr.base_address == 0")?;
+/// let matcher = LeaderMatcher::new("ldr.base_addr == 0")?;
 /// assert!(matcher.is_match(&leader, &options));
 ///
 /// let matcher = LeaderMatcher::new("ldr.encoding == 'a'")?;

--- a/src/matcher/leader/parse.rs
+++ b/src/matcher/leader/parse.rs
@@ -30,7 +30,7 @@ pub(crate) fn parse_leader_field(
     i: &mut &[u8],
 ) -> ModalResult<LeaderField> {
     alt((
-        "base_address".value(LeaderField::BaseAddr),
+        "base_addr".value(LeaderField::BaseAddr),
         "encoding".value(LeaderField::Encoding),
         "length".value(LeaderField::Length),
         "status".value(LeaderField::Status),
@@ -55,7 +55,7 @@ mod tests {
             };
         }
 
-        parse_success!("base_address", LeaderField::BaseAddr);
+        parse_success!("base_addr", LeaderField::BaseAddr);
         parse_success!("encoding", LeaderField::Encoding);
         parse_success!("length", LeaderField::Length);
         parse_success!("status", LeaderField::Status);
@@ -83,7 +83,7 @@ mod tests {
         );
 
         parse_success!(
-            "ldr.base_address == 32",
+            "ldr.base_addr == 32",
             LeaderMatcher {
                 field: LeaderField::BaseAddr,
                 operator: ComparisonOperator::Eq,

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -275,7 +275,7 @@ mod tests {
         );
 
         assert_eq!(
-            Query::new("ldr.base_address")?.dtypes(),
+            Query::new("ldr.base_addr")?.dtypes(),
             vec![DataType::UInt32]
         );
 

--- a/tests/api/matcher/comparison.rs
+++ b/tests/api/matcher/comparison.rs
@@ -23,7 +23,7 @@ fn compare_leader_fields() -> TestResult {
     let matcher = RecordMatcher::new("ldr.length < 3613")?;
     assert!(matcher.is_match(&record, &options));
 
-    let matcher = RecordMatcher::new("ldr.base_address == 589")?;
+    let matcher = RecordMatcher::new("ldr.base_addr == 589")?;
     assert!(matcher.is_match(&record, &options));
 
     let matcher = RecordMatcher::new("ldr.status == 'n'")?;

--- a/tests/api/path.rs
+++ b/tests/api/path.rs
@@ -25,8 +25,8 @@ fn path_leader_field() -> TestResult {
     let values = record.path(&path, &options);
     assert_eq!(values, vec!["z"]);
 
-    // base_address
-    let path = Path::new("ldr.base_address")?;
+    // base_addr
+    let path = Path::new("ldr.base_addr")?;
     let values = record.path(&path, &options);
     assert_eq!(values, vec!["589"]);
 

--- a/tests/api/query.rs
+++ b/tests/api/query.rs
@@ -48,8 +48,8 @@ fn query_leader_field() -> TestResult {
     let values = record.query(&query, &options);
     assert_eq!(values, vec![vec!["z"]]);
 
-    // base_address
-    let query = Query::new("ldr.base_address")?;
+    // base_addr
+    let query = Query::new("ldr.base_addr")?;
     let values = record.query(&query, &options);
     assert_eq!(values, vec![vec!["589"]]);
 


### PR DESCRIPTION
Closes #280 